### PR TITLE
feat/add-private-subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ No modules.
 | [aws_route_table_association.vpc-terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_security_group.alb-docker-instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc-terraform-all-traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_subnet.subnet-private-terraform-east1a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.subnet-private-terraform-east1c](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.subnet-public-terraform-east1a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.subnet-public-terraform-east1c](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.vpc-terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
@@ -36,6 +38,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_private_subnets"></a> [create\_private\_subnets](#input\_create\_private\_subnets) | Flag to create private subnets | `bool` | `false` | no |
 | <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | list of volumes to attach on instances | `list(any)` | n/a | yes |
 | <a name="input_instance_docker_count"></a> [instance\_docker\_count](#input\_instance\_docker\_count) | The number of instances app to create | `number` | `2` | no |
 | <a name="input_instance_name_prefix"></a> [instance\_name\_prefix](#input\_instance\_name\_prefix) | Prefix for the names of the instances | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,18 @@
 #Map para criacao das instancias
 locals {
-  subnets_map = {
-    "subnet-east1a" = aws_subnet.subnet-public-terraform-east1a.id,
-    "subnet-east1c" = aws_subnet.subnet-public-terraform-east1c.id
+  public_subnets = {
+    "subnet-east1a-public" = aws_subnet.subnet-public-terraform-east1a.id,
+    "subnet-east1c-public" = aws_subnet.subnet-public-terraform-east1c.id,
   }
+
+  private_subnets = var.create_private_subnets ? {
+    "subnet-east1a-private" = aws_subnet.subnet-private-terraform-east1a[0].id,
+    "subnet-east1c-private" = aws_subnet.subnet-private-terraform-east1c[0].id
+  } : {}
+
+  subnets_map = merge(local.public_subnets, local.private_subnets)
 }
+
 # Extraindo as chaves do mapa de sub-redes para criar instâncias alternando nas sub-redes
 locals {
   subnet_keys = keys(var.subnets_map)
@@ -64,6 +72,20 @@ resource "aws_subnet" "subnet-public-terraform-east1c" {
   vpc_id            = aws_vpc.vpc-terraform.id
   availability_zone = "us-east-1c"
   cidr_block        = cidrsubnet(aws_vpc.vpc-terraform.cidr_block, 3, 2)
+}
+
+resource "aws_subnet" "subnet-private-terraform-east1a" {
+  count             = var.create_private_subnets ? 1 : 0
+  vpc_id            = aws_vpc.vpc-terraform.id
+  availability_zone = "us-east-1a"
+  cidr_block        = cidrsubnet(aws_vpc.vpc-terraform.cidr_block, 3, 1)
+}
+
+resource "aws_subnet" "subnet-private-terraform-east1c" {
+  count             = var.create_private_subnets ? 1 : 0
+  vpc_id            = aws_vpc.vpc-terraform.id
+  availability_zone = "us-east-1c"
+  cidr_block        = cidrsubnet(aws_vpc.vpc-terraform.cidr_block, 3, 3)
 }
 
 # Associando as subnets criadas a tabela de rotas

--- a/variables.tf
+++ b/variables.tf
@@ -35,3 +35,9 @@ variable "subnets_map" {
   type        = map(string)
   description = "Map of subnet IDs to distribute instances"
 }
+
+variable "create_private_subnets" {
+  description = "Flag to create private subnets"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Criação de sub-redes privadas
- Modificações realizadas para permitir a criação de subnets privadas
- A flag de criação será definida no repositório de produto
- Quando criadas as subnets privadas, as rotas são automaticamente associadas a estas.